### PR TITLE
body property added for sent and consumed message stats

### DIFF
--- a/ClientMonitoringExtension.php
+++ b/ClientMonitoringExtension.php
@@ -43,7 +43,8 @@ class ClientMonitoringExtension implements PostSendExtensionInterface
             $context->getTransportMessage()->getMessageId(),
             $context->getTransportMessage()->getCorrelationId(),
             $context->getTransportMessage()->getHeaders(),
-            $context->getTransportMessage()->getProperties()
+            $context->getTransportMessage()->getProperties(),
+            $context->getTransportMessage()->getBody()
         );
 
         $this->safeCall(function () use ($stats) {

--- a/ConsumedMessageStats.php
+++ b/ConsumedMessageStats.php
@@ -52,6 +52,11 @@ class ConsumedMessageStats implements Stats
     protected $properties;
 
     /**
+     * @var string
+     */
+    protected $body;
+
+    /**
      * @var bool;
      */
     protected $redelivered;
@@ -100,6 +105,7 @@ class ConsumedMessageStats implements Stats
         ?string $correlationId,
         array $headers,
         array $properties,
+        string $body,
         bool $redelivered,
         string $status,
         string $errorClass = null,
@@ -117,6 +123,7 @@ class ConsumedMessageStats implements Stats
         $this->correlationId = $correlationId;
         $this->headers = $headers;
         $this->properties = $properties;
+        $this->body = $body;
         $this->redelivered = $redelivered;
         $this->status = $status;
 
@@ -166,6 +173,11 @@ class ConsumedMessageStats implements Stats
     public function getProperties(): array
     {
         return $this->properties;
+    }
+
+    public function getBody(): string
+    {
+        return $this->body;
     }
 
     public function isRedelivered(): bool

--- a/ConsumerMonitoringExtension.php
+++ b/ConsumerMonitoringExtension.php
@@ -174,6 +174,7 @@ class ConsumerMonitoringExtension implements StartExtensionInterface, PreSubscri
             $context->getMessage()->getCorrelationId(),
             $context->getMessage()->getHeaders(),
             $context->getMessage()->getProperties(),
+            $context->getMessage()->getBody(),
             $context->getMessage()->isRedelivered(),
             ConsumedMessageStats::STATUS_FAILED,
             get_class($context->getException()),
@@ -256,6 +257,7 @@ class ConsumerMonitoringExtension implements StartExtensionInterface, PreSubscri
             $context->getMessage()->getCorrelationId(),
             $context->getMessage()->getHeaders(),
             $context->getMessage()->getProperties(),
+            $context->getMessage()->getBody(),
             $context->getMessage()->isRedelivered(),
             $status
         );

--- a/SentMessageStats.php
+++ b/SentMessageStats.php
@@ -41,6 +41,11 @@ class SentMessageStats implements Stats
      */
     protected $properties;
 
+    /**
+     * @var string
+     */
+    protected $body;
+
     public function __construct(
         int $timestampMs,
         string $destination,
@@ -48,7 +53,8 @@ class SentMessageStats implements Stats
         ?string $messageId,
         ?string $correlationId,
         array $headers,
-        array $properties
+        array $properties,
+        string $body
     ) {
         $this->timestampMs = $timestampMs;
         $this->destination = $destination;
@@ -57,6 +63,7 @@ class SentMessageStats implements Stats
         $this->correlationId = $correlationId;
         $this->headers = $headers;
         $this->properties = $properties;
+        $this->body = $body;
     }
 
     public function getTimestampMs(): int
@@ -92,5 +99,10 @@ class SentMessageStats implements Stats
     public function getProperties(): array
     {
         return $this->properties;
+    }
+
+    public function getBody(): string
+    {
+        return $this->body;
     }
 }


### PR DESCRIPTION
Hello guys!

It could be useful if body could be part of the `SentMessageStats` and `ConsumedMessageStats`.

e.g.
- if we want to check persisted statuses for rejected messages, I would personally like to see body payload as it could speed up process of finding out if anything is wrong with payload
 - if we have a system for requeuing messages, and we want to shallow clone and enqueue all messages with specific stats param from persisted statuses, we would need body for being able to make correct messages

Thoughts?